### PR TITLE
Textfield should not become first responder after recipient is selected

### DIFF
--- a/TURecipientBar/TURecipientsBar.m
+++ b/TURecipientBar/TURecipientsBar.m
@@ -656,11 +656,6 @@ void *TURecipientsSelectionContext = &TURecipientsSelectionContext;
 			_selectedRecipient = recipient;
 			
 			[self _updateRecipientTextField];
-			
-			if (_selectedRecipient != nil) {
-                // TODO: CITY-3968 need to implement fix for scrolling to bottom, maybe add delete recipient instead of textfield backspace
-				//[_textField becomeFirstResponder];
-			}
 		}
 		
 		for (UIButton *recipientView in _recipientViews) {

--- a/TURecipientBar/TURecipientsBar.m
+++ b/TURecipientBar/TURecipientsBar.m
@@ -658,7 +658,8 @@ void *TURecipientsSelectionContext = &TURecipientsSelectionContext;
 			[self _updateRecipientTextField];
 			
 			if (_selectedRecipient != nil) {
-				[_textField becomeFirstResponder];
+                // TODO: CITY-3968 need to implement fix for scrolling to bottom, maybe add delete recipient instead of textfield backspace
+				//[_textField becomeFirstResponder];
 			}
 		}
 		


### PR DESCRIPTION
This code fixes an issue that comes up when users tap on a recipient, then the list scrolls back to the end of a long list.  It should stay with the selected recipient.  Tapping outside of the recipient does scroll to the bottom if you want to add more people.